### PR TITLE
feat: span granularity components

### DIFF
--- a/delorean/date_utils/__init__.py
+++ b/delorean/date_utils/__init__.py
@@ -52,6 +52,27 @@ def _strict_zip(*iterables: Iterable) -> Iterable:
 VALID_GRAINS_COMB = dict(_strict_zip(
     [item for name, item in DateGranularity.__members__.items()],
     [
-        {SpanGranularity.DAILY},
+        {
+            SpanGranularity.DAILY,
+            SpanGranularity.PERIODIC,
+            SpanGranularity.WEEKLY,
+            SpanGranularity.MONTHLY,
+            SpanGranularity.YEARLY,
+        },
+        {
+            SpanGranularity.DAILY,
+            SpanGranularity.PERIODIC,
+            SpanGranularity.WEEKLY,
+            SpanGranularity.MONTHLY,
+        },
+        {
+            SpanGranularity.DAILY,
+            SpanGranularity.PERIODIC,
+            SpanGranularity.WEEKLY,
+        },
+        {
+            SpanGranularity.DAILY,
+            SpanGranularity.PERIODIC,
+        },
     ],
 ))

--- a/delorean/date_utils/common.py
+++ b/delorean/date_utils/common.py
@@ -1,0 +1,49 @@
+import datetime
+from datetime import timedelta
+
+
+def get_week_anchor_date(a_date: datetime.date) -> datetime.date:
+    """
+    Thursday of week determine the year and month that week belongs to
+    """
+    assert isinstance(a_date, datetime.date)
+    weekday = a_date.weekday()
+    date_delta = 3 - weekday
+    key_date = a_date + timedelta(days=date_delta)
+    return key_date
+
+
+def get_weeks_offset_between_dates(
+    prev_date: datetime.date,
+    cur_date: datetime.date,
+) -> int:
+    """
+    Count of week offset from
+    the week that prev_date belonging
+    to the week that cur_date belonging to
+    """
+    assert isinstance(prev_date, datetime.date)
+    assert isinstance(cur_date, datetime.date)
+    assert cur_date >= prev_date
+    cur_week_key_date = get_week_anchor_date(cur_date)
+    prev_week_key_date = get_week_anchor_date(prev_date)
+    return ((cur_week_key_date - prev_week_key_date).days + 1) // 7
+
+
+def get_start_date_of_monthly_start_week(year: int, month: int) -> datetime.date:
+    """
+    get the start date of week
+    which is the first week of given month
+    """
+    assert isinstance(year, int)
+    assert isinstance(month, int)
+    assert year > 0
+    assert 1 <= month <= 12
+    belonging_month_first_date = datetime.date(year, month, 1)
+    first_date_weekday = belonging_month_first_date.weekday()
+    if first_date_weekday <= 3:
+        date_delta = 3 - first_date_weekday
+    else:
+        date_delta = 10 - first_date_weekday
+    first_week_start_date = belonging_month_first_date + timedelta(days=date_delta) - timedelta(days=3)
+    return first_week_start_date

--- a/delorean/date_utils/date_granularity.py
+++ b/delorean/date_utils/date_granularity.py
@@ -120,6 +120,9 @@ class DateGranularity(Enum):
     supported date granularity
     """
     DAILY = Daily()
+    WEEKLY = Weekly()
+    MONTHLY = Monthly()
+    YEARLY = Yearly()
 
     def validate_date_completion(
         self,

--- a/delorean/date_utils/span_granularity.py
+++ b/delorean/date_utils/span_granularity.py
@@ -150,7 +150,11 @@ class SpanGranularity(Enum):
     """
     supported date span granularity
     """
-    DAILY = 'daily'
+    DAILY = Daily()
+    WEEKLY = Weekly()
+    MONTHLY = Monthly()
+    YEARLY = Yearly()
+    PERIODIC = Periodic()
 
 
 class DateSpan:

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -1,0 +1,74 @@
+import datetime
+from unittest import TestCase
+
+from delorean.date_utils.common import (
+    get_start_date_of_monthly_start_week,
+    get_week_anchor_date,
+    get_weeks_offset_between_dates,
+)
+
+
+class GetWeekAnchorDateTestCase(TestCase):
+
+    def test_with_date_before_thursday(self):
+        sample_date = datetime.date(2024, 6, 10)
+        self.assertEqual(
+            get_week_anchor_date(sample_date),
+            datetime.date(2024, 6, 13),
+        )
+
+    def test_with_thursday(self):
+        sample_date = datetime.date(2023, 3, 2)
+        self.assertEqual(
+            get_week_anchor_date(sample_date),
+            datetime.date(2023, 3, 2),
+        )
+
+    def test_with_date_after_thursday(self):
+        sample_date = datetime.date(2020, 2, 29)
+        self.assertEqual(
+            get_week_anchor_date(sample_date),
+            datetime.date(2020, 2, 27),
+        )
+
+
+class GetWeeksOffsetBetweenDatesTestCase(TestCase):
+
+    def test_get_weeks_offset_between_dates(self):
+        prev_date = datetime.date(2024, 6, 10)
+        cur_date = datetime.date(2024, 6, 21)
+        self.assertEqual(
+            get_weeks_offset_between_dates(prev_date, cur_date),
+            25 - 24,
+        )
+
+    def test_offset_cross_months(self):
+        prev_date = datetime.date(2024, 2, 29)
+        cur_date = datetime.date(2024, 6, 21)
+        self.assertEqual(
+            get_weeks_offset_between_dates(prev_date, cur_date),
+            25 - 9,
+        )
+
+    def test_offset_cross_years(self):
+        prev_date = datetime.date(2019, 12, 3)
+        cur_date = datetime.date(2021, 3, 21)
+        self.assertEqual(
+            get_weeks_offset_between_dates(prev_date, cur_date),
+            11 + 53 + (52 - 49),
+        )
+
+
+class GetStartDateOfMonthlyStartWeekTestCase(TestCase):
+
+    def test_get_start_date_of_monthly_start_week(self):
+        self.assertEqual(
+            get_start_date_of_monthly_start_week(2024, 6),
+            datetime.date(2024, 6, 3),
+        )
+
+    def test_start_date_at_another_month(self):
+        self.assertEqual(
+            get_start_date_of_monthly_start_week(2024, 5),
+            datetime.date(2024, 4, 29),
+        )

--- a/tests/unittest/date_utils/test_span_granularity.py
+++ b/tests/unittest/date_utils/test_span_granularity.py
@@ -1,0 +1,370 @@
+import datetime
+from unittest import TestCase
+
+from delorean.date_utils.date_range import DateRange
+from delorean.date_utils.date_granularity import DateGranularity
+from delorean.date_utils.span_granularity import (
+    Daily,
+    Weekly,
+    Monthly,
+    Yearly,
+    Periodic,
+)
+
+
+class SpanGranularityDailyTestCase(TestCase):
+
+    def setUp(self):
+        self.granularity = Daily()
+
+    def test_name(self):
+        self.assertEqual(self.granularity.name, 'daily')
+
+    def test_daily_first_period_index(self):
+        start_date = datetime.date(2024, 6, 18)
+        end_date = datetime.date(2024, 6, 21)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_unsupported_weekly_date_granularity(self):
+        start_date = datetime.date(2024, 6, 17)
+        end_date = datetime.date(2024, 6, 23)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        with self.assertRaises(NotImplementedError):
+            self.granularity.get_first_period_index(date_range)
+
+    def test_unsupported_monthly_date_granularity(self):
+        start_date = datetime.date(2024, 1, 1)
+        end_date = datetime.date(2024, 1, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.MONTHLY,
+        )
+        with self.assertRaises(NotImplementedError):
+            self.granularity.get_first_period_index(date_range)
+
+    def test_unsupported_yearly_date_granularity(self):
+        start_date = datetime.date(2024, 1, 1)
+        end_date = datetime.date(2024, 12, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.YEARLY,
+        )
+        with self.assertRaises(NotImplementedError):
+            self.granularity.get_first_period_index(date_range)
+
+
+class SpanGranularityWeeklyTestCase(TestCase):
+
+    def setUp(self):
+        self.granularity = Weekly()
+
+    def test_name(self):
+        self.assertEqual(self.granularity.name, 'weekly')
+
+    def test_daily_first_period_index(self):
+        start_date = datetime.date(2024, 6, 18)
+        end_date = datetime.date(2024, 6, 21)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            1,
+        )
+
+    def test_weekly_first_period_index(self):
+        start_date = datetime.date(2024, 6, 3)
+        end_date = datetime.date(2024, 6, 23)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_unsupported_monthly_date_granularity(self):
+        start_date = datetime.date(2024, 1, 1)
+        end_date = datetime.date(2024, 1, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.MONTHLY,
+        )
+        with self.assertRaises(NotImplementedError):
+            self.granularity.get_first_period_index(date_range)
+
+    def test_unsupported_yearly_date_granularity(self):
+        start_date = datetime.date(2024, 1, 1)
+        end_date = datetime.date(2024, 12, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.YEARLY,
+        )
+        with self.assertRaises(NotImplementedError):
+            self.granularity.get_first_period_index(date_range)
+
+
+class SpanGranularityMonthlyTestCase(TestCase):
+
+    def setUp(self):
+        self.granularity = Monthly()
+
+    def test_name(self):
+        self.assertEqual(self.granularity.name, 'monthly')
+
+    def test_daily_first_period_index(self):
+        start_date = datetime.date(2024, 6, 18)
+        end_date = datetime.date(2024, 6, 21)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            17,
+        )
+
+    def test_daily_first_period_index_in_leap_year_feb(self):
+        start_date = datetime.date(2016, 2, 29)
+        end_date = datetime.date(2016, 3, 14)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            28,
+        )
+
+    def test_weekly_first_period_index(self):
+        start_date = datetime.date(2024, 2, 26)
+        end_date = datetime.date(2024, 3, 10)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            4,
+        )
+
+    def test_weekly_first_period_index_at_another_month(self):
+        start_date = datetime.date(2024, 4, 29)
+        end_date = datetime.date(2024, 5, 12)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_monthly_first_period_index(self):
+        start_date = datetime.date(2024, 1, 1)
+        end_date = datetime.date(2024, 1, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.MONTHLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_unsupported_yearly_date_granularity(self):
+        start_date = datetime.date(2024, 1, 1)
+        end_date = datetime.date(2024, 12, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.YEARLY,
+        )
+        with self.assertRaises(NotImplementedError):
+            self.granularity.get_first_period_index(date_range)
+
+
+class SpanGranularityYearlyTestCase(TestCase):
+
+    def setUp(self):
+        self.granularity = Yearly()
+
+    def test_name(self):
+        self.assertEqual(self.granularity.name, 'yearly')
+
+    def test_daily_first_period_index(self):
+        start_date = datetime.date(2024, 6, 18)
+        end_date = datetime.date(2024, 6, 21)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            169,
+        )
+
+    def test_daily_first_period_index_in_leap_year(self):
+        start_date = datetime.date(2024, 12, 31)
+        end_date = datetime.date(2024, 12, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            365,
+        )
+
+    def test_weekly_first_period_index(self):
+        start_date = datetime.date(2024, 6, 10)
+        end_date = datetime.date(2024, 6, 23)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            23,
+        )
+
+    def test_weekly_first_period_index_at_another_year(self):
+        start_date = datetime.date(2018, 12, 31)
+        end_date = datetime.date(2019, 1, 6)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_weekly_first_period_index_at_fifty_week_year(self):
+        start_date = datetime.date(2015, 12, 28)
+        end_date = datetime.date(2016, 1, 3)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            52,
+        )
+
+    def test_monthly_first_period_index(self):
+        start_date = datetime.date(2023, 12, 1)
+        end_date = datetime.date(2024, 6, 30)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.MONTHLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            11,
+        )
+
+    def test_yearly_first_period_index(self):
+        start_date = datetime.date(2023, 1, 1)
+        end_date = datetime.date(2024, 12, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.YEARLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+
+class SpanGranularityPeriodicTestCase(TestCase):
+
+    def setUp(self):
+        self.granularity = Periodic()
+
+    def test_name(self):
+        self.assertEqual(self.granularity.name, 'periodic')
+
+    def test_daily_first_period_index(self):
+        start_date = datetime.date(2024, 6, 18)
+        end_date = datetime.date(2024, 6, 21)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.DAILY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_weekly_first_period_index(self):
+        start_date = datetime.date(2024, 6, 10)
+        end_date = datetime.date(2024, 6, 23)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.WEEKLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_monthly_first_period_index(self):
+        start_date = datetime.date(2023, 12, 1)
+        end_date = datetime.date(2024, 6, 30)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.MONTHLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )
+
+    def test_yearly_first_period_index(self):
+        start_date = datetime.date(2023, 1, 1)
+        end_date = datetime.date(2024, 12, 31)
+        date_range = DateRange(
+            start_date,
+            end_date,
+            DateGranularity.YEARLY,
+        )
+        self.assertEqual(
+            self.granularity.get_first_period_index(date_range),
+            0,
+        )


### PR DESCRIPTION
implement core interfaces

1.`get_first_period_index`: calculate the index among the span's granularity of given date range's first period