### PR TITLE
feat: support given firstweekday

### DIFF
--- a/deloreans/api.py
+++ b/deloreans/api.py
@@ -16,12 +16,29 @@ def get(
     date_granularity: DateGranularity,
     offset: int,
     offset_granularity: OffsetGranularity,
+    firstweekday: int = 0,
 ) -> Tuple[datetime.date, datetime.date]:
+    """
+    provide compared date range according to given parameters
+
+    Args:
+        start_date (datetime.date): start date of date range
+        end_date (datetime.date): end date of date range
+        date_granularity (DateGranularity): granularity of date range, e.g. daily, weekly
+        offset (int): away from given date range, to the future when positive
+        offset_granularity (OffsetGranularity): granularity of offset period, e.g. year-over-year
+        firstweekday (int): define the start date's weekday of week, 0 is Monday, 6 is Sunday
+
+    Returns:
+        compared_start_date (datetime.date): start date of compared date range
+        compared_end_date (datetime.date): end date of compared date range
+    """
     component = DeLoreans(
         start_date,
         end_date,
         date_granularity,
         offset,
         offset_granularity,
+        firstweekday,
     )
     return component.get()

--- a/deloreans/app.py
+++ b/deloreans/app.py
@@ -70,7 +70,10 @@ class DeLoreans:
                 f'{self._date_grain_name} period\'s index in {self._offset_grain_name} period '
                 f'has not been implemented'
             )
-        return func(self._date_range.start_date)
+        return func(
+            self._date_range.start_date,
+            firstweekday=self._date_range.firstweekday,
+        )
 
     def _get_compared_located_period_start_date(self) -> datetime.date:
         if self._date_period_offset.offset_granularity == OffsetGranularity.PERIODIC:

--- a/deloreans/app.py
+++ b/deloreans/app.py
@@ -123,7 +123,11 @@ class DeLoreans:
                 f'{self._date_grain_name} period with index in {self._offset_grain_name} period '
                 f'has not been implemented'
             )
-        return func(located_period_start_date, period_index)
+        return func(
+            located_period_start_date,
+            period_index,
+            firstweekday=self._date_range.firstweekday,
+        )
 
     def get(self) -> Tuple[datetime.date, datetime.date]:
         """
@@ -148,10 +152,12 @@ class DeLoreans:
         given_date_range_length = date_granularity.get_date_range_length(
             self._date_range.start_date,
             self._date_range.end_date,
+            self._date_range.firstweekday,
         )
         compared_end_date = date_granularity.get_end_date(
             compared_start_date,
             given_date_range_length,
+            self._date_range.firstweekday
         )
 
         return compared_start_date, compared_end_date

--- a/deloreans/app.py
+++ b/deloreans/app.py
@@ -97,7 +97,11 @@ class DeLoreans:
                 f'start {self._date_grain_name} period in {self._offset_grain_name} period '
                 f'has not been implemented'
             )
-        return func(self._date_range.start_date, offset)
+        return func(
+            self._date_range.start_date,
+            offset,
+            firstweekday=self._date_range.firstweekday,
+        )
 
     def _get_compared_start_date(
         self,

--- a/deloreans/app.py
+++ b/deloreans/app.py
@@ -25,8 +25,14 @@ class DeLoreans:
         date_granularity: DateGranularity,
         offset: int,
         offset_granularity: OffsetGranularity,
+        firstweekday: int = 0,
     ) -> None:
-        self._date_range = DateRange(start_date, end_date, date_granularity)
+        self._date_range = DateRange(
+            start_date,
+            end_date,
+            date_granularity,
+            firstweekday,
+        )
         self._date_period_offset = DatePeriodOffset(offset, offset_granularity)
         self._validate_grain_comb()
         self._date_grain_name = date_granularity.name.lower()

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -1,5 +1,6 @@
 import datetime
 from datetime import timedelta
+from typing import Any
 
 
 def get_weekly_start_date(
@@ -101,8 +102,12 @@ def get_start_daily_of_daily(a_date: datetime.date) -> datetime.date:
     return a_date
 
 
-def get_start_daily_of_weekly(a_date: datetime.date) -> datetime.date:
-    return get_weekly_start_date(a_date)
+def get_start_daily_of_weekly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    return get_weekly_start_date(a_date, firstweekday)
 
 
 def get_start_daily_of_monthly(a_date: datetime.date) -> datetime.date:
@@ -113,21 +118,41 @@ def get_start_daily_of_yearly(a_date: datetime.date) -> datetime.date:
     return datetime.date(a_date.year, 1, 1)
 
 
-def get_start_weekly_of_weekly(a_date: datetime.date) -> datetime.date:
-    return get_weekly_start_date(a_date)
+def get_start_weekly_of_weekly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    return get_weekly_start_date(a_date, firstweekday)
 
 
-def get_start_weekly_of_monthly(a_date: datetime.date) -> datetime.date:
-    week_anchor_date = get_week_anchor_date(a_date)
-    return get_start_weekly_of_month(week_anchor_date.year, week_anchor_date.month)
+def get_start_weekly_of_monthly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    week_anchor_date = get_week_anchor_date(a_date, firstweekday)
+    return get_start_weekly_of_month(
+        week_anchor_date.year,
+        week_anchor_date.month,
+        firstweekday,
+    )
 
 
-def get_start_weekly_of_yearly(a_date: datetime.date) -> datetime.date:
+def get_start_weekly_of_yearly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> datetime.date:
     """
     special case that the month is January
     """
-    week_anchor_date = get_week_anchor_date(a_date)
-    return get_start_weekly_of_month(week_anchor_date.year, 1)
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    week_anchor_date = get_week_anchor_date(a_date, firstweekday)
+    return get_start_weekly_of_month(
+        week_anchor_date.year,
+        1,
+        firstweekday,
+    )
 
 
 def get_start_monthly_of_monthly(a_date: datetime.date) -> datetime.date:
@@ -170,51 +195,90 @@ def get_start_yearly_of_yearly(a_date: datetime.date) -> datetime.date:
 # =================================================================================================
 
 
-def get_daily_index_of_daily(a_date: datetime.date) -> int:  # NOQA
+def get_daily_index_of_daily(
+    a_date: datetime.date,  # NOQA
+    **kwargs: Any,  # NOQA
+) -> int:
     return 0
 
 
-def get_daily_index_of_weekly(a_date: datetime.date) -> int:
-    start_date = get_start_daily_of_weekly(a_date)
+def get_daily_index_of_weekly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> int:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    start_date = get_start_daily_of_weekly(a_date, firstweekday=firstweekday)
     return (a_date - start_date).days
 
 
-def get_daily_index_of_monthly(a_date: datetime.date) -> int:
+def get_daily_index_of_monthly(
+    a_date: datetime.date,
+    **kwargs: Any,  # NOQA
+) -> int:
     start_date = get_start_daily_of_monthly(a_date)
     return (a_date - start_date).days
 
 
-def get_daily_index_of_yearly(a_date: datetime.date) -> int:
+def get_daily_index_of_yearly(
+    a_date: datetime.date,
+    **kwargs: Any,  # NOQA
+) -> int:
     start_date = get_start_daily_of_yearly(a_date)
     return (a_date - start_date).days
 
 
-def get_weekly_index_of_weekly(a_date: datetime.date) -> int:  # NOQA
+def get_weekly_index_of_weekly(
+    a_date: datetime.date,  # NOQA
+    **kwargs: Any,  # NOQA
+) -> int:
     return 0
 
 
-def get_weekly_index_of_monthly(a_date: datetime.date) -> int:
-    located_start_date = get_start_weekly_of_monthly(a_date)
-    week_start_date = get_weekly_start_date(a_date)
+def get_weekly_index_of_monthly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> int:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    located_start_date = get_start_weekly_of_monthly(
+        a_date,
+        firstweekday=firstweekday,
+    )
+    week_start_date = get_weekly_start_date(a_date, firstweekday)
     return (week_start_date - located_start_date).days // 7
 
 
-def get_weekly_index_of_yearly(a_date: datetime.date) -> int:
-    located_start_date = get_start_weekly_of_yearly(a_date)
-    week_start_date = get_weekly_start_date(a_date)
+def get_weekly_index_of_yearly(
+    a_date: datetime.date,
+    **kwargs: Any,
+) -> int:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    located_start_date = get_start_weekly_of_yearly(
+        a_date,
+        firstweekday=firstweekday,
+    )
+    week_start_date = get_weekly_start_date(a_date, firstweekday)
     return (week_start_date - located_start_date).days // 7
 
 
-def get_monthly_index_of_monthly(a_date: datetime.date) -> int:  # NOQA
+def get_monthly_index_of_monthly(
+    a_date: datetime.date,  # NOQA
+    **kwargs: Any,  # NOQA
+) -> int:
     return 0
 
 
-def get_monthly_index_of_yearly(a_date: datetime.date) -> int:
+def get_monthly_index_of_yearly(
+    a_date: datetime.date,
+    **kwargs: Any,  # NOQA
+) -> int:
     located_start_date = get_start_monthly_of_yearly(a_date)
     return a_date.month - located_start_date.month
 
 
-def get_yearly_index_of_yearly(a_date: datetime.date) -> int:  # NOQA
+def get_yearly_index_of_yearly(
+    a_date: datetime.date,  # NOQA
+    **kwargs: Any,  # NOQA
+) -> int:
     return 0
 
 

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -13,12 +13,14 @@ def get_weekly_start_date(
     return a_date - timedelta(days=date_index)
 
 
-def get_week_anchor_date(a_date: datetime.date) -> datetime.date:
+def get_week_anchor_date(
+    a_date: datetime.date,
+    firstweekday: int = 0,
+) -> datetime.date:
     """
     The fourth day of week determine the year and month that week located
     """
-    assert isinstance(a_date, datetime.date)
-    start_date = get_weekly_start_date(a_date)
+    start_date = get_weekly_start_date(a_date, firstweekday)
     return start_date + timedelta(days=3)
 
 

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -27,6 +27,7 @@ def get_week_anchor_date(
 def get_weeks_offset(
     base_date: datetime.date,
     compared_date: datetime.date,
+    firstweekday: int = 0,
 ) -> int:
     """
     Weeks offset between the weeks which given dates located
@@ -36,9 +37,11 @@ def get_weeks_offset(
          compared_date is 2024-06-01, which is at 2024 no.22 week
 
          then the offset of week is 22 - 18 = 4
+
+    involve custom first weekday, the week which date located could be different
     """
-    base_week_anchor_date = get_week_anchor_date(base_date)
-    compared_week_anchor_date = get_week_anchor_date(compared_date)
+    base_week_anchor_date = get_week_anchor_date(base_date, firstweekday)
+    compared_week_anchor_date = get_week_anchor_date(compared_date, firstweekday)
     return ((compared_week_anchor_date - base_week_anchor_date).days + 1) // 7
 
 

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -45,24 +45,28 @@ def get_weeks_offset(
     return ((compared_week_anchor_date - base_week_anchor_date).days + 1) // 7
 
 
-def get_start_weekly_of_month(year: int, month: int) -> datetime.date:
+def get_start_weekly_of_month(
+    year: int,
+    month: int,
+    firstweekday: int = 0,
+) -> datetime.date:
     """
     get the start week of a month,
     which is represented by week's start date
     """
-    assert isinstance(year, int)
-    assert isinstance(month, int)
-    assert year > 0
-    assert 1 <= month <= 12
+    _firstweekday = firstweekday % 7
     daily_start_date = datetime.date(year, month, 1)
-    week_anchor_date = get_week_anchor_date(daily_start_date)
+    week_anchor_date = get_week_anchor_date(
+        daily_start_date,
+        _firstweekday,
+    )
 
     # the week represented by anchor date is in previous month
     # so that the first week should be the next one
     if daily_start_date > week_anchor_date:
-        return get_weekly_start_date(daily_start_date + timedelta(days=7))
+        daily_start_date = daily_start_date + timedelta(days=7)
 
-    return get_weekly_start_date(daily_start_date)
+    return get_weekly_start_date(daily_start_date, _firstweekday)
 
 
 # ==========================================================================================================

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -2,11 +2,14 @@ import datetime
 from datetime import timedelta
 
 
-def get_weekly_start_date(a_date: datetime.date) -> datetime.date:
+def get_weekly_start_date(
+    a_date: datetime.date,
+    firstweekday: int = 0,
+) -> datetime.date:
     """
     get the start date of week which given date located
     """
-    date_index = a_date.weekday()
+    date_index = (a_date.weekday() - firstweekday) % 7
     return a_date - timedelta(days=date_index)
 
 

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -311,15 +311,31 @@ def get_yearly_index_of_yearly(
 # =================================================================================================
 
 
-def get_compared_start_daily_located_daily(a_date: datetime.date, offset: int) -> datetime.date:
+def get_compared_start_daily_located_daily(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     return a_date + timedelta(days=offset)
 
 
-def get_compared_start_daily_located_weekly(a_date: datetime.date, offset: int) -> datetime.date:
-    return get_start_daily_of_weekly(a_date) + timedelta(weeks=offset)
+def get_compared_start_daily_located_weekly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    return get_start_daily_of_weekly(
+        a_date,
+        firstweekday=firstweekday,
+    ) + timedelta(weeks=offset)
 
 
-def get_compared_start_daily_located_monthly(a_date: datetime.date, offset: int) -> datetime.date:
+def get_compared_start_daily_located_monthly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     located_start_date = get_start_daily_of_monthly(a_date)
     located_year, located_month = located_start_date.year, located_start_date.month
 
@@ -332,34 +348,80 @@ def get_compared_start_daily_located_monthly(a_date: datetime.date, offset: int)
     return datetime.date(compared_year, compared_month, 1)
 
 
-def get_compared_start_daily_located_yearly(a_date: datetime.date, offset: int) -> datetime.date:
+def get_compared_start_daily_located_yearly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     located_start_date = get_start_daily_of_yearly(a_date)
     return datetime.date(located_start_date.year + offset, 1, 1)
 
 
-def get_compared_start_weekly_located_weekly(a_date: datetime.date, offset: int) -> datetime.date:
-    located_start_date = get_start_weekly_of_weekly(a_date)
+def get_compared_start_weekly_located_weekly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    located_start_date = get_start_weekly_of_weekly(
+        a_date,
+        firstweekday=firstweekday,
+    )
     return located_start_date + timedelta(weeks=offset)
 
 
-def get_compared_start_weekly_located_monthly(a_date: datetime.date, offset: int) -> datetime.date:
-    week_anchor_date = get_week_anchor_date(a_date)
-    compared_month_start_date = get_compared_start_daily_located_monthly(week_anchor_date, offset)
-    return get_start_weekly_of_month(compared_month_start_date.year, compared_month_start_date.month)
+def get_compared_start_weekly_located_monthly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    week_anchor_date = get_week_anchor_date(a_date, firstweekday)
+    compared_month_start_date = get_compared_start_daily_located_monthly(
+        week_anchor_date,
+        offset,
+        firstweekday=firstweekday,
+    )
+    return get_start_weekly_of_month(
+        compared_month_start_date.year,
+        compared_month_start_date.month,
+        firstweekday,
+    )
 
 
-def get_compared_start_weekly_located_yearly(a_date: datetime.date, offset: int) -> datetime.date:
-    week_anchor_date = get_week_anchor_date(a_date)
-    compared_year_start_date = get_compared_start_daily_located_yearly(week_anchor_date, offset)
-    return get_start_weekly_of_month(compared_year_start_date.year, 1)
+def get_compared_start_weekly_located_yearly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    week_anchor_date = get_week_anchor_date(a_date, firstweekday)
+    compared_year_start_date = get_compared_start_daily_located_yearly(
+        week_anchor_date,
+        offset,
+        firstweekday=firstweekday,
+    )
+    return get_start_weekly_of_month(
+        compared_year_start_date.year,
+        1,
+        firstweekday,
+    )
 
 
-def get_compared_start_monthly_located_monthly(a_date: datetime.date, offset: int) -> datetime.date:
+def get_compared_start_monthly_located_monthly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     located_start_date = get_start_monthly_of_monthly(a_date)
     return get_compared_start_daily_located_monthly(located_start_date, offset)
 
 
-def get_compared_start_monthly_located_yearly(a_date: datetime.date, offset: int) -> datetime.date:
+def get_compared_start_monthly_located_yearly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     """
     special case that the month is January
     """
@@ -367,7 +429,11 @@ def get_compared_start_monthly_located_yearly(a_date: datetime.date, offset: int
     return datetime.date(located_start_date.year + offset, 1, 1)
 
 
-def get_compared_start_yearly_located_yearly(a_date: datetime.date, offset: int) -> datetime.date:
+def get_compared_start_yearly_located_yearly(
+    a_date: datetime.date,
+    offset: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     located_start_date = get_start_yearly_of_yearly(a_date)
     return datetime.date(located_start_date.year + offset, 1, 1)
 

--- a/deloreans/date_utils/common.py
+++ b/deloreans/date_utils/common.py
@@ -461,21 +461,34 @@ def get_compared_start_yearly_located_yearly(
 # =================================================================================================
 
 
-def get_daily_with_index_in_daily(a_date: datetime.date, index: int) -> datetime.date:  # NOQA
+def get_daily_with_index_in_daily(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     if index != 0:
         raise ValueError
     return a_date
 
 
-def get_daily_with_index_in_weekly(a_date: datetime.date, index: int) -> datetime.date:
+def get_daily_with_index_in_weekly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     # since one week only has 7 days
     if not 0 <= index < 7:
         raise ValueError
-    week_start_date = get_weekly_start_date(a_date)
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    week_start_date = get_weekly_start_date(a_date, firstweekday=firstweekday)
     return week_start_date + timedelta(days=index)
 
 
-def get_daily_with_index_in_monthly(a_date: datetime.date, index: int) -> datetime.date:
+def get_daily_with_index_in_monthly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     next_month_total_months = (a_date.year * 12 + a_date.month) + 1
     exceeded_year = next_month_total_months // 12
     exceeded_month = next_month_total_months % 12
@@ -495,7 +508,11 @@ def get_daily_with_index_in_monthly(a_date: datetime.date, index: int) -> dateti
     return month_start_date + timedelta(days=index)
 
 
-def get_daily_with_index_in_yearly(a_date: datetime.date, index: int) -> datetime.date:
+def get_daily_with_index_in_yearly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     year_start_date = datetime.date(a_date.year, 1, 1)
     year_end_date = datetime.date(a_date.year, 12, 31)
     capacity = (year_end_date - year_start_date).days + 1
@@ -506,52 +523,99 @@ def get_daily_with_index_in_yearly(a_date: datetime.date, index: int) -> datetim
     return year_start_date + timedelta(days=index)
 
 
-def get_weekly_with_index_in_weekly(a_date: datetime.date, index: int) -> datetime.date:  # NOQA
+def get_weekly_with_index_in_weekly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,
+) -> datetime.date:
     if index != 0:
         raise ValueError
-    return get_weekly_start_date(a_date)
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    return get_weekly_start_date(a_date, firstweekday=firstweekday)
 
 
-def get_weekly_with_index_in_monthly(a_date: datetime.date, index: int) -> datetime.date:
-    anchor_date = get_week_anchor_date(a_date)
-    month_start_week_date = get_start_weekly_of_month(anchor_date.year, anchor_date.month)
+def get_weekly_with_index_in_monthly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    anchor_date = get_week_anchor_date(
+        a_date,
+        firstweekday=firstweekday,
+    )
+    month_start_week_date = get_start_weekly_of_month(
+        anchor_date.year,
+        anchor_date.month,
+        firstweekday=firstweekday,
+    )
     start_date = month_start_week_date + timedelta(weeks=index)
 
     # each month has different amount of weeks
     # if index is out of month's capacity, raise exception
-    week_anchor_date = get_week_anchor_date(start_date)
-    if any([week_anchor_date.year != anchor_date.year, week_anchor_date.month != anchor_date.month]):
+    week_anchor_date = get_week_anchor_date(
+        start_date,
+        firstweekday=firstweekday,
+    )
+    if any([
+        week_anchor_date.year != anchor_date.year,
+        week_anchor_date.month != anchor_date.month,
+    ]):
         raise ValueError
     return start_date
 
 
-def get_weekly_with_index_in_yearly(a_date: datetime.date, index: int) -> datetime.date:
-    anchor_date = get_week_anchor_date(a_date)
-    year_start_week_date = get_start_weekly_of_month(anchor_date.year, 1)
+def get_weekly_with_index_in_yearly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,
+) -> datetime.date:
+    firstweekday: int = kwargs.get('firstweekday', 0)
+    anchor_date = get_week_anchor_date(
+        a_date,
+        firstweekday=firstweekday,
+    )
+    year_start_week_date = get_start_weekly_of_month(
+        anchor_date.year,
+        1,
+        firstweekday,
+    )
     start_date = year_start_week_date + timedelta(weeks=index)
 
     # each month has different amount of weeks
     # if index is out of month's capacity, raise exception
-    week_anchor_date = get_week_anchor_date(start_date)
+    week_anchor_date = get_week_anchor_date(start_date, firstweekday)
     if week_anchor_date.year != anchor_date.year:
         raise ValueError
     return start_date
 
 
-def get_monthly_with_index_in_monthly(a_date: datetime.date, index: int) -> datetime.date:  # NOQA
+def get_monthly_with_index_in_monthly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     if index != 0:
         raise ValueError
     return datetime.date(a_date.year, a_date.month, 1)
 
 
-def get_monthly_with_index_in_yearly(a_date: datetime.date, index: int) -> datetime.date:
+def get_monthly_with_index_in_yearly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     year_start_date = datetime.date(a_date.year, 1, 1)
     if not 0 <= index < 12:
         raise ValueError
     return datetime.date(year_start_date.year, year_start_date.month + index, 1)
 
 
-def get_yearly_with_index_in_yearly(a_date: datetime.date, index: int) -> datetime.date:
+def get_yearly_with_index_in_yearly(
+    a_date: datetime.date,
+    index: int,
+    **kwargs: Any,  # NOQA
+) -> datetime.date:
     if index != 0:
         raise ValueError
     return datetime.date(a_date.year, 1, 1)

--- a/deloreans/date_utils/date_granularity.py
+++ b/deloreans/date_utils/date_granularity.py
@@ -54,6 +54,7 @@ class BaseGranularity:
         cls,
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
         """
         Provide the count of date periods with given granularity
@@ -61,7 +62,8 @@ class BaseGranularity:
         """
         if start_date > end_date:
             raise ValueError
-        cls.validate_date_completion(start_date, end_date)
+        if not cls.validate_date_completion(start_date, end_date, firstweekday):
+            raise ValueError
         return cls._get_date_range_length(start_date, end_date)
 
     @staticmethod
@@ -267,8 +269,13 @@ class DateGranularity(Enum):
         self,
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
-        return self.value.get_date_range_length(start_date, end_date)
+        return self.value.get_date_range_length(
+            start_date,
+            end_date,
+            firstweekday,
+        )
 
     def get_end_date(
         self,

--- a/deloreans/date_utils/date_granularity.py
+++ b/deloreans/date_utils/date_granularity.py
@@ -130,7 +130,7 @@ class Weekly(BaseGranularity):
         a_date: datetime.date,
         firstweekday: int = 0,
     ) -> bool:
-        week_start_date = get_weekly_start_date(a_date)
+        week_start_date = get_weekly_start_date(a_date, firstweekday)
         return a_date == week_start_date
 
     @staticmethod
@@ -138,7 +138,10 @@ class Weekly(BaseGranularity):
         a_date: datetime.date,
         firstweekday: int = 0,
     ) -> bool:
-        next_week_start_date = get_weekly_start_date(a_date + timedelta(days=7))
+        next_week_start_date = get_weekly_start_date(
+            a_date + timedelta(days=7),
+            firstweekday,
+        )
         week_end_date = next_week_start_date + timedelta(days=-1)
         return a_date == week_end_date
 

--- a/deloreans/date_utils/date_granularity.py
+++ b/deloreans/date_utils/date_granularity.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from deloreans.date_utils.common import (
     get_weekly_start_date,
+    get_weeks_offset,
     get_start_monthly_of_monthly,
     get_compared_start_monthly_located_monthly,
     get_start_yearly_of_yearly,
@@ -62,14 +63,13 @@ class BaseGranularity:
         """
         if start_date > end_date:
             raise ValueError
-        if not cls.validate_date_completion(start_date, end_date, firstweekday):
-            raise ValueError
-        return cls._get_date_range_length(start_date, end_date)
+        return cls._get_date_range_length(start_date, end_date, firstweekday)
 
     @staticmethod
     def _get_date_range_length(
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
         raise NotImplementedError
 
@@ -118,6 +118,7 @@ class Daily(BaseGranularity):
     def _get_date_range_length(
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
         return (end_date - start_date).days + 1
 
@@ -155,8 +156,9 @@ class Weekly(BaseGranularity):
     def _get_date_range_length(
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
-        return int(((end_date - start_date).days + 1) / 7)
+        return get_weeks_offset(start_date, end_date, firstweekday) + 1
 
     @staticmethod
     def _get_end_date(
@@ -190,6 +192,7 @@ class Monthly(BaseGranularity):
     def _get_date_range_length(
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
         start_total_months = 12 * start_date.year + start_date.month
         end_total_months = 12 * end_date.year + end_date.month
@@ -231,6 +234,7 @@ class Yearly(BaseGranularity):
     def _get_date_range_length(
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> int:
         return end_date.year - start_date.year + 1
 

--- a/deloreans/date_utils/date_granularity.py
+++ b/deloreans/date_utils/date_granularity.py
@@ -18,25 +18,32 @@ class BaseGranularity:
         cls,
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> bool:
         if start_date > end_date:
             raise ValueError
 
-        is_start_date = cls._is_start_date(start_date)
-        is_end_date = cls._is_end_date(end_date)
+        is_start_date = cls._is_start_date(start_date, firstweekday)
+        is_end_date = cls._is_end_date(end_date, firstweekday)
         if all([is_start_date, is_end_date]):
             return True
         return False
 
     @staticmethod
-    def _is_start_date(a_date: datetime.date) -> bool:
+    def _is_start_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         """
         Whether the given date is the start date of granularity-unit date period or not
         """
         raise NotImplementedError
 
     @staticmethod
-    def _is_end_date(a_date: datetime.date) -> bool:
+    def _is_end_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         """
         Whether the given date is the end date of granularity-unit date period or not
         """
@@ -88,11 +95,17 @@ class BaseGranularity:
 class Daily(BaseGranularity):
 
     @staticmethod
-    def _is_start_date(a_date: datetime.date) -> bool:  # NOQA
+    def _is_start_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         return True
 
     @staticmethod
-    def _is_end_date(a_date: datetime.date) -> bool:  # NOQA
+    def _is_end_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         return True
 
     @staticmethod
@@ -113,12 +126,18 @@ class Daily(BaseGranularity):
 class Weekly(BaseGranularity):
 
     @staticmethod
-    def _is_start_date(a_date: datetime.date) -> bool:
+    def _is_start_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         week_start_date = get_weekly_start_date(a_date)
         return a_date == week_start_date
 
     @staticmethod
-    def _is_end_date(a_date: datetime.date) -> bool:
+    def _is_end_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         next_week_start_date = get_weekly_start_date(a_date + timedelta(days=7))
         week_end_date = next_week_start_date + timedelta(days=-1)
         return a_date == week_end_date
@@ -142,12 +161,18 @@ class Weekly(BaseGranularity):
 class Monthly(BaseGranularity):
 
     @staticmethod
-    def _is_start_date(a_date: datetime.date) -> bool:
+    def _is_start_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         month_start_date = get_start_monthly_of_monthly(a_date)
         return a_date == month_start_date
 
     @staticmethod
-    def _is_end_date(a_date: datetime.date) -> bool:
+    def _is_end_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         exceeded_month_start_date = get_compared_start_monthly_located_monthly(a_date, 1)
         month_end_date = exceeded_month_start_date + timedelta(days=-1)
         return a_date == month_end_date
@@ -177,12 +202,18 @@ class Monthly(BaseGranularity):
 class Yearly(BaseGranularity):
 
     @staticmethod
-    def _is_start_date(a_date: datetime.date) -> bool:
+    def _is_start_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         year_start_date = get_start_yearly_of_yearly(a_date)
         return a_date == year_start_date
 
     @staticmethod
-    def _is_end_date(a_date: datetime.date) -> bool:
+    def _is_end_date(
+        a_date: datetime.date,
+        firstweekday: int = 0,
+    ) -> bool:
         exceeded_start_date = get_compared_start_yearly_located_yearly(a_date, 1)
         year_end_date = exceeded_start_date + timedelta(days=-1)
         return a_date == year_end_date
@@ -219,15 +250,13 @@ class DateGranularity(Enum):
         self,
         start_date: datetime.date,
         end_date: datetime.date,
+        firstweekday: int = 0,
     ) -> None:
-        """
-        validate date range completion according to the granularity
-
-        Args:
-            start_date (datetime.date): start of date range
-            end_date (datetime.date): end of date range
-        """
-        is_completion = self.value.validate_date_completion(start_date, end_date)
+        is_completion = self.value.validate_date_completion(
+            start_date,
+            end_date,
+            firstweekday,
+        )
         if not is_completion:
             raise ValueError
 

--- a/deloreans/date_utils/date_granularity.py
+++ b/deloreans/date_utils/date_granularity.py
@@ -78,8 +78,12 @@ class BaseGranularity:
         cls,
         start_date: datetime.date,
         date_range_length: int,
+        firstweekday: int = 0,
     ) -> datetime.date:
-        if not cls._is_start_date(start_date):
+        if not cls._is_start_date(
+            start_date,
+            firstweekday,
+        ):
             raise ValueError
         if date_range_length < 1:
             raise ValueError
@@ -281,5 +285,10 @@ class DateGranularity(Enum):
         self,
         start_date: datetime.date,
         date_range_length: int,
+        firstweekday: int = 0,
     ) -> datetime.date:
-        return self.value.get_end_date(start_date, date_range_length)
+        return self.value.get_end_date(
+            start_date,
+            date_range_length,
+            firstweekday,
+        )

--- a/deloreans/date_utils/date_range.py
+++ b/deloreans/date_utils/date_range.py
@@ -23,6 +23,7 @@ class DateRange:
         self._date_granularity.validate_date_completion(
             self._start_date,
             self._end_date,
+            self._firstweekday,
         )
 
     @property

--- a/deloreans/date_utils/date_range.py
+++ b/deloreans/date_utils/date_range.py
@@ -10,10 +10,13 @@ class DateRange:
         start_date: datetime.date,
         end_date: datetime.date,
         date_granularity: DateGranularity,
+        firstweekday: int = 0,
     ):
         self._start_date = start_date
         self._end_date = end_date
         self._date_granularity = date_granularity
+        self._firstweekday = firstweekday
+        self._validate_firstweekday()
         self._validate_date_type()
         self._validate_date_relativity()
         self._validate_date_granularity_type()
@@ -33,6 +36,10 @@ class DateRange:
     @property
     def date_granularity(self) -> DateGranularity:
         return self._date_granularity
+
+    @property
+    def firstweekday(self) -> int:
+        return self._firstweekday
 
     def _validate_date_type(self) -> None:
         """
@@ -62,3 +69,9 @@ class DateRange:
             raise ValueError(
                 f'Invalid date granularity {self._date_granularity!r}, should be DateGranularity'
             )
+
+    def _validate_firstweekday(self):
+        if not isinstance(self._firstweekday, int):
+            raise TypeError
+        if not 0 <= self._firstweekday < 7:
+            raise ValueError

--- a/tests/happypath.py
+++ b/tests/happypath.py
@@ -43,6 +43,27 @@ class HappyPathTestCase(TestCase):
         self.assertEqual(actual_start_date, expected_start_date)
         self.assertEqual(actual_end_date, expected_end_date)
 
+    def test_week_date_year_over_year_with_sunday_as_first_weekday(self):
+        """
+        compared week date period which is at previous month
+        and week starts from Sunday to Saturday
+
+        e.g. first 8 weeks at 2024 compared with previous year
+        """
+        sample_kwargs = {
+            'start_date': datetime.date(2023, 12, 31),
+            'end_date': datetime.date(2024, 2, 24),
+            'date_granularity': DateGranularity.WEEKLY,
+            'offset': -1,
+            'offset_granularity': OffsetGranularity.YEARLY,
+            'firstweekday': 6,
+        }
+        actual_start_date, actual_end_date = deloreans.get(**sample_kwargs)
+        expected_start_date = datetime.date(2023, 1, 1)
+        expected_end_date = datetime.date(2023, 2, 25)
+        self.assertEqual(actual_start_date, expected_start_date)
+        self.assertEqual(actual_end_date, expected_end_date)
+
     def test_half_year_vs_half_year(self):
         """
         2nd half year vs 1st half year

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -487,6 +487,19 @@ class GetComparedStartPeriodLocatedPeriodTestCase(TestCase):
             datetime.date(2024, 4, 29),
         )
 
+    def test_get_compared_start_daily_located_weekly_with_saturday_start(self):
+        sample_date = datetime.date(2024, 6, 18)
+        sample_offset = -7
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_compared_start_daily_located_weekly(
+                sample_date,
+                sample_offset,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 4, 27),
+        )
+
     def test_get_compared_start_daily_located_monthly(self):
         sample_date = datetime.date(2024, 6, 18)
         sample_offset = -6
@@ -519,12 +532,38 @@ class GetComparedStartPeriodLocatedPeriodTestCase(TestCase):
             datetime.date(2023, 12, 18),
         )
 
+    def test_get_compared_start_weekly_located_weekly_with_sunday_start(self):
+        sample_date = datetime.date(2024, 6, 3)
+        sample_offset = -24
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_compared_start_weekly_located_weekly(
+                sample_date,
+                sample_offset,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2023, 12, 17),
+        )
+
     def test_get_compared_start_weekly_located_monthly(self):
         sample_date = datetime.date(2024, 2, 26)
         sample_offset = -4
         self.assertEqual(
             get_compared_start_weekly_located_monthly(sample_date, sample_offset),
             datetime.date(2023, 10, 2),
+        )
+
+    def test_get_compared_start_weekly_located_monthly_with_saturday_start(self):
+        sample_date = datetime.date(2024, 2, 26)
+        sample_offset = -4
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_compared_start_weekly_located_monthly(
+                sample_date,
+                sample_offset,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2023, 9, 30),
         )
 
     def test_get_compared_start_weekly_located_monthly_which_has_another_month_num(self):
@@ -541,6 +580,19 @@ class GetComparedStartPeriodLocatedPeriodTestCase(TestCase):
         self.assertEqual(
             get_compared_start_weekly_located_yearly(sample_date, sample_offset),
             datetime.date(2021, 1, 4),
+        )
+
+    def test_get_compared_start_weekly_located_yearly_with_sunday_start(self):
+        sample_date = datetime.date(2024, 6, 10)
+        sample_offset = -3
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_compared_start_weekly_located_yearly(
+                sample_date,
+                sample_offset,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2021, 1, 3),
         )
 
     def test_get_compared_start_weekly_located_yearly_which_has_another_year_num(self):

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -112,6 +112,14 @@ class GetWeekAnchorDateTestCase(TestCase):
             datetime.date(2020, 2, 27),
         )
 
+    def test_anchor_date_when_start_saturday(self):
+        sample_date = datetime.date(2024, 6, 10)
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_week_anchor_date(sample_date, sample_firstweekday),
+            datetime.date(2024, 6, 11),
+        )
+
 
 class GetWeeksOffsetTestCase(TestCase):
 

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -646,6 +646,19 @@ class GetPeriodWithIndexInUnitPeriodTestCase(TestCase):
             datetime.date(2024, 6, 22),
         )
 
+    def test_get_daily_with_index_in_weekly_start_from_saturday(self):
+        sample_date = datetime.date(2024, 6, 17)
+        sample_index = 5
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_daily_with_index_in_weekly(
+                sample_date,
+                sample_index,
+                firstweekday=sample_firstweekday
+            ),
+            datetime.date(2024, 6, 20),
+        )
+
     def test_get_daily_with_index_in_monthly(self):
         sample_date = datetime.date(2024, 6, 1)
         sample_index = 13
@@ -676,6 +689,19 @@ class GetPeriodWithIndexInUnitPeriodTestCase(TestCase):
             datetime.date(2024, 6, 3),
         )
 
+    def test_get_weekly_with_index_in_weekly_which_start_from_sunday(self):
+        sample_date = datetime.date(2024, 6, 3)
+        sample_index = 0
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_weekly_with_index_in_weekly(
+                sample_date,
+                sample_index,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 6, 2),
+        )
+
     def test_get_weekly_with_index_in_monthly(self):
         sample_date = datetime.date(2024, 1, 29)
         sample_index = 3
@@ -684,12 +710,40 @@ class GetPeriodWithIndexInUnitPeriodTestCase(TestCase):
             datetime.date(2024, 2, 19),
         )
 
+    def test_get_weekly_with_index_in_monthly_with_sunday_start(self):
+        # When week start weekday is Sunday
+        # 2024-01-29 would be the first day of week which belongs to Jan 2024
+        sample_date = datetime.date(2024, 1, 29)
+        sample_index = 3
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_weekly_with_index_in_monthly(
+                sample_date,
+                sample_index,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 1, 21),
+        )
+
     def test_get_weekly_with_index_in_yearly(self):
         sample_date = datetime.date(2024, 1, 1)
         sample_index = 49
         self.assertEqual(
             get_weekly_with_index_in_yearly(sample_date, sample_index),
             datetime.date(2024, 12, 9),
+        )
+
+    def test_get_weekly_with_index_in_yearly_with_saturday_start(self):
+        sample_date = datetime.date(2024, 1, 1)
+        sample_index = 49
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_weekly_with_index_in_yearly(
+                sample_date,
+                sample_index,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 12, 7),
         )
 
     def test_get_monthly_with_index_in_monthly(self):

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -147,6 +147,19 @@ class GetWeeksOffsetTestCase(TestCase):
             11 + 53 + (52 - 49),
         )
 
+    def test_offset_cross_years_with_sunday_start(self):
+        sample_base_date = datetime.date(2019, 12, 3)
+        sample_compared_date = datetime.date(2021, 3, 21)
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_weeks_offset(
+                sample_base_date,
+                sample_compared_date,
+                sample_firstweekday,
+            ),
+            12 + 53 + (52 - 49),  # 2021-03-21 would locate at Week 12, 2021 when week starts with Sunday
+        )
+
 
 class GetStartWeeklyOfMonthTestCase(TestCase):
 

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -203,6 +203,17 @@ class GetLocatedPeriodStartDateTestCase(TestCase):
             datetime.date(2024, 6, 17),
         )
 
+    def test_get_start_daily_of_weekly_with_sunday_start(self):
+        sample_date = datetime.date(2024, 6, 18)
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_start_daily_of_weekly(
+                sample_date,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 6, 16),
+        )
+
     def test_get_start_daily_of_monthly(self):
         start_date = datetime.date(2024, 6, 18)
         self.assertEqual(
@@ -238,11 +249,33 @@ class GetLocatedPeriodStartDateTestCase(TestCase):
             datetime.date(2024, 6, 3),
         )
 
+    def test_get_start_weekly_of_weekly_with_sunday_start(self):
+        sample_date = datetime.date(2024, 6, 3)
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_start_weekly_of_weekly(
+                sample_date,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 6, 2),
+        )
+
     def test_get_start_weekly_of_monthly(self):
         start_date = datetime.date(2024, 2, 26)
         self.assertEqual(
             get_start_weekly_of_monthly(start_date),
             datetime.date(2024, 1, 29),
+        )
+
+    def test_get_start_weekly_of_monthly_with_saturday_start(self):
+        sample_date = datetime.date(2024, 2, 26)
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_start_weekly_of_monthly(
+                sample_date,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2024, 2, 3),
         )
 
     def test_get_start_weekly_of_monthly_which_has_another_month_num(self):
@@ -257,6 +290,17 @@ class GetLocatedPeriodStartDateTestCase(TestCase):
         self.assertEqual(
             get_start_weekly_of_yearly(start_date),
             datetime.date(2024, 1, 1),
+        )
+
+    def test_get_start_weekly_of_yearly_with_sunday_start(self):
+        sample_date = datetime.date(2024, 6, 10)
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_start_weekly_of_yearly(
+                sample_date,
+                firstweekday=sample_firstweekday,
+            ),
+            datetime.date(2023, 12, 31),
         )
 
     def test_get_start_weekly_of_yearly_which_has_another_year_num(self):
@@ -353,6 +397,17 @@ class GetPeriodIdxTestCase(TestCase):
             4,
         )
 
+    def test_get_weekly_index_of_monthly_with_saturday_start(self):
+        sample_date = datetime.date(2024, 2, 26)
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_weekly_index_of_monthly(
+                sample_date,
+                firstweekday=sample_firstweekday,
+            ),
+            3,
+        )
+
     def test_get_weekly_index_of_monthly_which_has_another_month_num(self):
         start_date = datetime.date(2024, 4, 29)
         self.assertEqual(
@@ -361,9 +416,20 @@ class GetPeriodIdxTestCase(TestCase):
         )
 
     def test_get_weekly_index_of_yearly(self):
-        start_date = datetime.date(2024, 6, 10)
+        sample_date = datetime.date(2024, 6, 9)
         self.assertEqual(
-            get_weekly_index_of_yearly(start_date),
+            get_weekly_index_of_yearly(sample_date),
+            22,
+        )
+
+    def test_get_weekly_index_of_yearly_with_sunday_start(self):
+        sample_date = datetime.date(2024, 6, 9)
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_weekly_index_of_yearly(
+                sample_date,
+                firstweekday=sample_firstweekday,
+            ),
             23,
         )
 

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -169,6 +169,17 @@ class GetStartWeeklyOfMonthTestCase(TestCase):
             datetime.date(2024, 6, 3),
         )
 
+    def test_get_start_weekly_of_month_with_sunday_start(self):
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_start_weekly_of_month(
+                2024,
+                6,
+                sample_firstweekday,
+            ),
+            datetime.date(2024, 6, 2),
+        )
+
     def test_start_date_at_another_month(self):
         self.assertEqual(
             get_start_weekly_of_month(2024, 5),

--- a/tests/unittest/date_utils/test_common.py
+++ b/tests/unittest/date_utils/test_common.py
@@ -72,6 +72,22 @@ class GetWeeklyStartDateTestCase(TestCase):
             datetime.date(2024, 12, 30),
         )
 
+    def test_start_from_sunday(self):
+        sample_date = datetime.date(2024, 6, 28)
+        sample_firstweekday = 6
+        self.assertEqual(
+            get_weekly_start_date(sample_date, sample_firstweekday),
+            datetime.date(2024, 6, 23),
+        )
+
+    def test_start_from_saturday(self):
+        sample_date = datetime.date(2024, 1, 3)
+        sample_firstweekday = 5
+        self.assertEqual(
+            get_weekly_start_date(sample_date, sample_firstweekday),
+            datetime.date(2023, 12, 30),
+        )
+
 
 class GetWeekAnchorDateTestCase(TestCase):
 

--- a/tests/unittest/date_utils/test_date_granularity.py
+++ b/tests/unittest/date_utils/test_date_granularity.py
@@ -91,6 +91,29 @@ class DateGranularityWeeklyTestCase(TestCase):
             4,
         )
 
+    def test_get_partial_date_range_length(self):
+        sample_start_date = datetime.date(2024, 5, 25)
+        sample_end_date = datetime.date(2024, 6, 21)
+        with self.assertRaises(ValueError):
+            self.granularity.get_date_range_length(
+                sample_start_date,
+                sample_end_date,
+            )
+
+    def test_get_date_range_length_with_saturday_start(self):
+        sample_start_date = datetime.date(2024, 5, 25)
+        sample_end_date = datetime.date(2024, 6, 21)
+        sample_firstweekday = 5
+
+        self.assertEqual(
+            self.granularity.get_date_range_length(
+                sample_start_date,
+                sample_end_date,
+                sample_firstweekday,
+            ),
+            4,
+        )
+
     def test_get_date_range_size_cross_year(self):
         start_date = datetime.date(2023, 12, 25)
         end_date = datetime.date(2024, 3, 31)

--- a/tests/unittest/date_utils/test_date_granularity.py
+++ b/tests/unittest/date_utils/test_date_granularity.py
@@ -94,11 +94,13 @@ class DateGranularityWeeklyTestCase(TestCase):
     def test_get_partial_date_range_length(self):
         sample_start_date = datetime.date(2024, 5, 25)
         sample_end_date = datetime.date(2024, 6, 21)
-        with self.assertRaises(ValueError):
+        self.assertEqual(
             self.granularity.get_date_range_length(
                 sample_start_date,
                 sample_end_date,
-            )
+            ),
+            25 - 21 + 1,  # Week 21 ~ Week 25, 2024
+        )
 
     def test_get_date_range_length_with_saturday_start(self):
         sample_start_date = datetime.date(2024, 5, 25)

--- a/tests/unittest/date_utils/test_date_granularity.py
+++ b/tests/unittest/date_utils/test_date_granularity.py
@@ -130,6 +130,30 @@ class DateGranularityWeeklyTestCase(TestCase):
             datetime.date(2024, 8, 4),
         )
 
+    def test_get_end_date_when_partial_with_sunday_start(self):
+        sample_start_date = datetime.date(2024, 6, 24)
+        sample_date_range_length = 6
+        sample_firstweekday = 6
+        with self.assertRaises(ValueError):
+            self.granularity.get_end_date(
+                sample_start_date,
+                sample_date_range_length,
+                sample_firstweekday,
+            )
+
+    def test_get_end_date_with_sunday_start(self):
+        sample_start_date = datetime.date(2024, 6, 23)
+        sample_date_range_length = 7
+        sample_firstweekday = 6
+        self.assertEqual(
+            self.granularity.get_end_date(
+                sample_start_date,
+                sample_date_range_length,
+                sample_firstweekday,
+            ),
+            datetime.date(2024, 8, 10),
+        )
+
 
 class DateGranularityMonthlyTestCase(TestCase):
 

--- a/tests/unittest/date_utils/test_date_granularity.py
+++ b/tests/unittest/date_utils/test_date_granularity.py
@@ -63,6 +63,26 @@ class DateGranularityWeeklyTestCase(TestCase):
         with self.assertRaises(ValueError):
             self.granularity.validate_date_completion(start_date, end_date)
 
+    def test_validate_partial_but_seven_times_day_weeks(self):
+        sample_start_date = datetime.date(2024, 6, 2)
+        sample_end_date = datetime.date(2024, 6, 29)
+
+        self.assertEqual(((sample_end_date - sample_start_date).days + 1) % 7, 0)
+        with self.assertRaises(ValueError):
+            self.granularity.validate_date_completion(sample_start_date, sample_end_date)
+
+    def test_validate_full_weeks_start_from_sunday(self):
+        sample_start_date = datetime.date(2024, 6, 2)
+        sample_end_date = datetime.date(2024, 6, 29)
+        sample_firstweekday = 6
+        self.assertIsNone(
+            self.granularity.validate_date_completion(
+                sample_start_date,
+                sample_end_date,
+                sample_firstweekday,
+            ),
+        )
+
     def test_get_date_range_length(self):
         start_date = datetime.date(2024, 5, 27)
         end_date = datetime.date(2024, 6, 23)

--- a/tests/unittest/date_utils/test_date_range.py
+++ b/tests/unittest/date_utils/test_date_range.py
@@ -55,6 +55,33 @@ class DateRangeTestCase(TestCase):
         self.assertEqual(end_date, date_range.end_date)
         self.assertEqual(firstweekday, date_range.firstweekday)
 
+    def test_weekly_completion(self):
+        start_date = datetime.date(2024, 2, 11)
+        end_date = datetime.date(2024, 2, 24)
+        date_granularity = DateGranularity.WEEKLY
+        with self.assertRaises(ValueError):
+            DateRange(
+                start_date,
+                end_date,
+                date_granularity,
+            )
+
+    def test_weekly_completion_with_sunday_start(self):
+        start_date = datetime.date(2024, 2, 11)
+        end_date = datetime.date(2024, 2, 24)
+        date_granularity = DateGranularity.WEEKLY
+        firstweekday = 6
+        date_range = DateRange(
+            start_date,
+            end_date,
+            date_granularity,
+            firstweekday,
+        )
+
+        self.assertEqual(start_date, date_range.start_date)
+        self.assertEqual(end_date, date_range.end_date)
+        self.assertEqual(firstweekday, date_range.firstweekday)
+
     def test_invalid_firstweekday_type(self):
         start_date = datetime.date(2024, 6, 10)
         end_date = datetime.date(2024, 6, 10)

--- a/tests/unittest/date_utils/test_date_range.py
+++ b/tests/unittest/date_utils/test_date_range.py
@@ -38,3 +38,47 @@ class DateRangeTestCase(TestCase):
         date_granularity = 'daily'
         with self.assertRaises(ValueError):
             DateRange(start_date, end_date, date_granularity)  # NOQA
+
+    def test_firstweekday(self):
+        start_date = datetime.date(2024, 6, 10)
+        end_date = datetime.date(2024, 6, 10)
+        date_granularity = DateGranularity.DAILY
+        firstweekday = 6
+        date_range = DateRange(
+            start_date,
+            end_date,
+            date_granularity,
+            firstweekday,
+        )
+
+        self.assertEqual(start_date, date_range.start_date)
+        self.assertEqual(end_date, date_range.end_date)
+        self.assertEqual(firstweekday, date_range.firstweekday)
+
+    def test_invalid_firstweekday_type(self):
+        start_date = datetime.date(2024, 6, 10)
+        end_date = datetime.date(2024, 6, 10)
+        date_granularity = DateGranularity.DAILY
+        firstweekday = '6'
+
+        with self.assertRaises(TypeError):
+            DateRange(
+                start_date,
+                end_date,
+                date_granularity,
+                firstweekday,  # NOQA
+            )
+
+    def test_invalid_firstweekday_value(self):
+        start_date = datetime.date(2024, 6, 10)
+        end_date = datetime.date(2024, 6, 10)
+        date_granularity = DateGranularity.DAILY
+        firstweekday = 9
+
+        with self.assertRaises(ValueError):
+            DateRange(
+                start_date,
+                end_date,
+                date_granularity,
+                firstweekday,
+            )

--- a/tests/unittest/test_app.py
+++ b/tests/unittest/test_app.py
@@ -42,3 +42,23 @@ class DeLoreansTestCase(TestCase):
             executor.get(),
             (datetime.date(2024, 6, 13), datetime.date(2024, 6, 19))
         )
+
+    def test_get_compared_date_range_with_given_firstweekday(self):
+        start_date = datetime.date(2024, 2, 11)
+        end_date = datetime.date(2024, 2, 24)
+        date_granularity = DateGranularity.WEEKLY
+        offset = -2
+        offset_granularity = OffsetGranularity.MONTHLY
+        firstweekday = 6
+        executor = DeLoreans(
+            start_date,
+            end_date,
+            date_granularity,
+            offset,
+            offset_granularity,
+            firstweekday,
+        )
+        self.assertEqual(
+            executor.get(),
+            (datetime.date(2023, 12, 10), datetime.date(2023, 12, 23))
+        )


### PR DESCRIPTION
Support parameter `firstweekday` which define the first day of a week

0 is Monday, and 6 is Sunday.

It can represent several week number system:
* `firstweekday=0`: ISO week (from `Monday` through `Sunday`)
* `firstweekday=6`: US system (from `Sunday` through `Saturday`)

However, the definition of one year / month's first week would still follow this rule referred to [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date#First_week):

> the fourth day of a week determine this week's affiliation since it presents the majority (4 or more) of a week